### PR TITLE
Expose CMake option to avoid Lapack/Blas conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,17 @@ ENDIF( NOT CMAKE_BUILD_TYPE )
 
 
 option(QPOASES_BUILD_EXAMPLES "Build examples." ON)
+option(QPOASES_AVOID_LA_NAMING_CONFLICTS "If ON, avoid to re-defined symbols that conflict with Blas/Lapack provided functions." OFF)
 
 
 ############################################################
 #################### compiler flags ########################
 ############################################################
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__NO_COPYRIGHT__")
+IF(QPOASES_AVOID_LA_NAMING_CONFLICTS)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__AVOID_LA_NAMING_CONFLICTS__")
+ENDIF()
+
 IF ( UNIX )
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wfloat-equal -Wshadow -DLINUX")
     SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_DEBUG} -O3 -finline-functions")


### PR DESCRIPTION
The problem described in https://github.com/coin-or/qpOASES/issues/60 was not solved when using CMake. This PR adds the CMake option `QPOASES_AVOID_LA_NAMING_CONFLICTS` (by default set to OFF, for backward compatibility) that enables the `__AVOID_LA_NAMING_CONFLICTS__` macro definition to permit to avoid Lapack/Blas symbol naming conflicts or confusion also when building the library with CMake. 