### PR TITLE
Permit to compile qpOASES as a shared library in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,12 @@ IF( NOT CMAKE_BUILD_TYPE )
         )
 ENDIF( NOT CMAKE_BUILD_TYPE )
 
-
+option(BUILD_SHARED_LIBS "If ON, build shared library instead of static" OFF)
 option(QPOASES_BUILD_EXAMPLES "Build examples." ON)
 
+IF(BUILD_SHARED_LIBS AND WIN32)
+    MESSAGE(FATAL_ERROR "Compiling qpOASES as a shared library in Windows is not supported.")
+ENDIF()
 
 ############################################################
 #################### compiler flags ########################
@@ -104,7 +107,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include)
 FILE(GLOB SRC src/*.cpp)
 
 # library
-ADD_LIBRARY(qpOASES STATIC ${SRC})
+ADD_LIBRARY(qpOASES ${SRC})
 INSTALL(TARGETS qpOASES
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
This modification permits to compile qpOASES on Unix as a shared library, leaving the default compilation to static for backward compatibility. Enabling the `BUILD_SHARED_LIBS`  option in CMake is explicitly disabled as visibility of symbols is not handled in the project, and using `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` (see https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/) is not working due to the use of some global variables (`struct _iobuf * qpOASES::stdFile`). 