### PR TITLE
Bump CMake PACKAGE_VERSION's to 3.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_minimum_required(VERSION 2.6)
 
 PROJECT(qpOASES CXX)
 SET(PACKAGE_NAME "qpOASES")
-SET(PACKAGE_VERSION "3.2.0")
+SET(PACKAGE_VERSION "3.2.2")
 SET(PACKAGE_SO_VERSION "3.2")
 SET(PACKAGE_DESCRIPTION "An implementation of the online active set strategy")
 SET(PACKAGE_AUTHOR "Hans Joachim Ferreau, Andreas Potschka, Christian Kirches et al.")


### PR DESCRIPTION
As mentioned in https://github.com/coin-or/qpOASES/issues/113, the `PACKAGE_VERSION` in CMake was lagging behind the tags/release (3.2.1 was tagged without the CMake version being updated). 

This PR bumps the `PACKAGE_VERSION` in CMake to 3.2.2 so that a 3.2.2 release/tag can be done without further source code modifications.