### PR TITLE
remove the compiler warning

### DIFF
--- a/src/Matrices.cpp
+++ b/src/Matrices.cpp
@@ -850,10 +850,8 @@ returnValue SparseMatrix::getRowNorm( real_t* norm, int_t type ) const
 			break;
 		case 1:
 			for ( j=0; j < nCols; ++j ) {
-				// FIXME please add guarding or fix indent for "for loop" to
-				//       remove compile warnings
 				for (i = jc[j]; i < jc[j+1]; i++);
-				  norm[ir[i]] += getAbs( val[i] );
+				norm[ir[i]] += getAbs( val[i] );
 			}
 			break;
 		default:


### PR DESCRIPTION
this change supposed to remove the warning about the second line not being guarded by the first line, with the original code looking like this (note the semicolon at the end of the first line):
```
   for (i = jc[j]; i < jc[j+1]; i++);
       norm[ir[i]] += getAbs( val[i] );
```