### PR TITLE
Makefile: add mkdir bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,14 @@ include make.mk
 ##
 
 
-all: src examples
+all: bin src examples
 #src_aw testing
 
 src:
 	@cd $@; ${MAKE} -s
+
+bin:
+	mkdir bin
 
 #src_aw:
 #	@cd $@; ${MAKE} -s


### PR DESCRIPTION
currently cloning this project and doing a simple `make` does not work as the bin directory is missing, see https://github.com/coin-or/qpOASES/issues/128.

solutions like https://github.com/coin-or/qpOASES/issues/114 are working. This PR does it automatically, now `make` and `make python` work from the `<install_dir>`