### PR TITLE
Update Mumps submodule uri

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/ThirdParty-Mumps"]
 	path = external/ThirdParty-Mumps
-	url = git@github.com:coin-or-tools/ThirdParty-Mumps.git
+	url = https://github.com/coin-or-tools/ThirdParty-Mumps.git


### PR DESCRIPTION
Hello,

This PR changes the URI used to retrieve the mumps submodule.

This allows cloning the project correctly even when an ssh key has not been setup