### PR TITLE
Update Makefile for matlab interface

### DIFF
--- a/interfaces/matlab/Makefile
+++ b/interfaces/matlab/Makefile
@@ -67,6 +67,7 @@ copyMs:
 	@${CP} qpOASES.m ${BINDIR}
 	@${CP} qpOASES_options.m ${BINDIR}
 	@${CP} qpOASES_sequence.m ${BINDIR}
+	@${CP} qpOASES_auxInput.m ${BINDIR}
 
 #@${CP} qpOASES_sequenceVM.m ${BINDIR}
 	


### PR DESCRIPTION
Add missing `qpOASES_auxInput.m` to list of files to be copied to `bin/`