### PR TITLE
Initialize BC_isBound to fix UBsan error

### DIFF
--- a/src/QProblem.cpp
+++ b/src/QProblem.cpp
@@ -5008,6 +5008,7 @@ returnValue QProblem::performStep(	const real_t* const delta_g,
 	tau = 1.0;
 	BC_idx = -1;
 	BC_status = ST_UNDEFINED;
+	BC_isBound = BT_FALSE;
 
 	int_t BC_idx_tmp = -1;
 


### PR DESCRIPTION
Fixed undefined behaviour where `BC_isBound` was used uninitialized.

In `QProblem::performStep()` the output parameter `BC_isBound` was only assigned conditionally when a blocking contraint was found. If no blocking constraint was detected (all ratio test passed), the variable remained uninitialized, causing UBSan to report an invalud value for `qpOASES::BolleanType`.

The fix adds explicit initialization `BC_isBound = BT_FALSE;` alongside the existing initaliazations for `BC_idx` and `BC_status` at the start of `performStep()`.